### PR TITLE
Trigger test on pull request

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -3,6 +3,8 @@ name: Test with Maven
 # Do lots of tests :)
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [ main, master ]
   push:
     branches:
       - '**'        # matches every branch


### PR DESCRIPTION
Pull request #27 didn't automatically run the GitHub Action to test with Maven. Adding a pull request trigger to the workflow should fix this.